### PR TITLE
fix: set default duration > 0

### DIFF
--- a/src/lib/marquee.jsx
+++ b/src/lib/marquee.jsx
@@ -28,8 +28,9 @@ export function Marquee({
   ...props
 }) {
   const [marqueeWidth, setMarqueeWidth] = useState(0)
-  const [duration, setDuration] = useState(1)
+  const [duration, setDuration] = useState(0)
   const [neededAmount, setNeededAmount] = useState(1)
+  const [isPlaying, setIsPlaying] = useState(false)
 
   const container = useRef()
   const marquee = useRef()
@@ -64,6 +65,8 @@ export function Marquee({
     } else {
       setDuration(marqueeWidth / speedAmount)
     }
+
+    setIsPlaying(playing)
   }, [prefersReducedMotion, reducedMotionSpeed, speed])
 
   const marquees = useMemo(() => {
@@ -107,11 +110,11 @@ export function Marquee({
     <div
       {...props}
       ref={container}
-      className={classnames(["marquee", className])}
+      className={classnames(["marquee", isPlaying && "is-playing", className])}
       style={{
         "--marquee-width": marqueeWidth,
         "--duration": `${duration}s`,
-        "--animation-state": playing ? "running" : "paused",
+        "--animation-state": isPlaying ? "running" : "paused",
       }}
     >
       <div ref={marquee} className="marquee__slide">

--- a/src/lib/marquee.jsx
+++ b/src/lib/marquee.jsx
@@ -28,7 +28,7 @@ export function Marquee({
   ...props
 }) {
   const [marqueeWidth, setMarqueeWidth] = useState(0)
-  const [duration, setDuration] = useState(0)
+  const [duration, setDuration] = useState(1)
   const [neededAmount, setNeededAmount] = useState(1)
 
   const container = useRef()
@@ -110,7 +110,7 @@ export function Marquee({
       className={classnames(["marquee", className])}
       style={{
         "--marquee-width": marqueeWidth,
-        "--duration": duration + `s`,
+        "--duration": `${duration}s`,
         "--animation-state": playing ? "running" : "paused",
       }}
     >

--- a/src/lib/marquee.scss
+++ b/src/lib/marquee.scss
@@ -5,7 +5,10 @@
 }
 
 .marquee {
-  animation: scroll var(--duration) linear infinite var(--animation-state, running);
+  &.is-playing {
+    animation: scroll var(--duration) linear infinite var(--animation-state, running);
+  }
+
   position: relative;
   display: grid;
   grid-auto-flow: column;


### PR DESCRIPTION
### Description of the Issue

Marquee is not playing on FireFox unless window is resized or reduced motion is toggled.

### Fix

Default duration state has been set to 1 (> 0).
When the default duration is > 0, Marquee will play as intended on Firefox

### Question
Anyone have any idea why this is happening?