### PR TITLE
fix: add animation delay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wethegit/react-marquee",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wethegit/react-marquee",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "prop-types": "~15.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/react-marquee",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "",
   "files": [
     "dist"

--- a/src/lib/marquee.scss
+++ b/src/lib/marquee.scss
@@ -6,6 +6,7 @@
 
 .marquee {
   animation: scroll var(--duration) linear infinite var(--animation-state, running);
+  animation-delay: 0.01s;
   position: relative;
   display: grid;
   grid-auto-flow: column;

--- a/src/lib/marquee.scss
+++ b/src/lib/marquee.scss
@@ -6,6 +6,14 @@
 
 .marquee {
   animation: scroll var(--duration) linear infinite var(--animation-state, running);
+
+  /*
+  * On Firefox, there is an issue where the Marquee does not play unless
+  * the window is resized or the play state is toggled.
+  *
+  * Setting an animation delay is a workaround fix for this issue.
+  * A low delay of 0.01s is set so it does not interfere with the animation.
+  */
   animation-delay: 0.01s;
   position: relative;
   display: grid;


### PR DESCRIPTION
Marquee is not playing on FireFox unless window is resized or reduced motion is toggled.

Adding an animation delay fixes this issue.