### PR TITLE
fix: set width of max-content to .marquee__slide

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wethegit/react-marquee",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wethegit/react-marquee",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "prop-types": "~15.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/react-marquee",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "",
   "files": [
     "dist"

--- a/src/lib/marquee.scss
+++ b/src/lib/marquee.scss
@@ -2,6 +2,7 @@
 .marquee__slide {
   display: grid;
   grid-auto-flow: column;
+  width: max-content;
 }
 
 .marquee {


### PR DESCRIPTION
### Issue

`width: max-content` was removed in v.2.0.0 from `.marquee__slide`. It doesn't cause any issues in the react-marquee example but content is being squished on a real site. Adding it back fixes this issue.

Could we add this back?