### PR TITLE
fix(safari): play state + content overlap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wethegit/react-marquee",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wethegit/react-marquee",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
         "prop-types": "~15.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/react-marquee",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "",
   "files": [
     "dist"

--- a/src/lib/marquee.jsx
+++ b/src/lib/marquee.jsx
@@ -107,7 +107,7 @@ export function Marquee({
     <div
       {...props}
       ref={container}
-      className={classnames(["marquee", marqueeWidth > 0 && "ready", className])}
+      className={classnames(["marquee", marqueeWidth > 0 && "marquee--ready", className])}
       style={{
         "--marquee-width": marqueeWidth,
         "--duration": duration + `s`,

--- a/src/lib/marquee.jsx
+++ b/src/lib/marquee.jsx
@@ -107,7 +107,7 @@ export function Marquee({
     <div
       {...props}
       ref={container}
-      className={classnames(["marquee", className])}
+      className={classnames(["marquee", marqueeWidth > 0 && "ready", className])}
       style={{
         "--marquee-width": marqueeWidth,
         "--duration": duration + `s`,

--- a/src/lib/marquee.scss
+++ b/src/lib/marquee.scss
@@ -1,30 +1,30 @@
-.marquee,
 .marquee__slide {
-  display: grid;
-  grid-auto-flow: column;
+  display: inline-block;
   width: max-content;
 }
-
 .marquee {
-  animation: scroll var(--duration) linear infinite var(--animation-state, running);
-
   /*
-  * On Firefox, there is an issue where the Marquee does not play unless
-  * the window is resized or the play state is toggled.
+  * On Firefox & Safari, there was an issue where the Marquee does not play
+  * unless the window is resized or the play state is toggled.
   *
-  * Setting an animation delay is a workaround fix for this issue.
-  * A low delay of 0.01s is set so it does not interfere with the animation.
+  * This was happening because the animation was loaded before the marqueeWidth
+  * had finished calculations, so the animation was animating
+  * with a marqueeWidth of 0. Adding an animation-delay of 0.01s
+  * fixed the issue in Firefox, but the issue still persisted in Safari.
+  *
+  * The .ready class aims to solve this issue for all cases by waiting
+  * until marqueeWidth is larger than the default of 0 before
+  * loading up the animation.
   */
-  animation-delay: 0.01s;
+  &.ready {
+    animation: scroll var(--duration) linear infinite var(--animation-state, running);
+  }
   position: relative;
-  display: grid;
-  grid-auto-flow: column;
-
+  white-space: nowrap;
   @keyframes scroll {
     0% {
       transform: translateX(0%);
     }
-
     100% {
       transform: translateX(calc(var(--marquee-width) * -1px));
     }

--- a/src/lib/marquee.scss
+++ b/src/lib/marquee.scss
@@ -1,8 +1,22 @@
+.marquee {
+  position: relative;
+  white-space: nowrap;
+  @keyframes scroll {
+    0% {
+      transform: translateX(0%);
+    }
+    100% {
+      transform: translateX(calc(var(--marquee-width) * -1px));
+    }
+  }
+}
+
 .marquee__slide {
   display: inline-block;
   width: max-content;
 }
-.marquee {
+
+.marquee--ready {
   /*
   * On Firefox & Safari, there was an issue where the Marquee does not play
   * unless the window is resized or the play state is toggled.
@@ -16,17 +30,5 @@
   * until marqueeWidth is larger than the default of 0 before
   * loading up the animation.
   */
-  &.ready {
-    animation: scroll var(--duration) linear infinite var(--animation-state, running);
-  }
-  position: relative;
-  white-space: nowrap;
-  @keyframes scroll {
-    0% {
-      transform: translateX(0%);
-    }
-    100% {
-      transform: translateX(calc(var(--marquee-width) * -1px));
-    }
-  }
+  animation: scroll var(--duration) linear infinite var(--animation-state, running);
 }


### PR DESCRIPTION
### Issue(s)

- Same issue as we had on FireFox, the marquee is not playing.
- Size of the grid container items were too small, caused content to overlap when there are too many items

In the last fix, we added an animation-delay of 0.01s which fixed it the issue on FireFox where the Marquee was not playing, but the issue persisted in Safari.

I came up with another solution - it seems like the animation is loaded up before marqueeWidth is calculated, so what's happening is the animation is doing a `transform: translateX(var(--marquee-width)` where `--marquee-width` is 0.

One of the previous ideas was to add a play/pause class, but adding classes in that way would cause content jumping when changing states. So instead of this, I conditionally added a `.ready` class when marqueeWidth > 0. This works on both FireFox and Safari with no content jumping.

As for the content overlap, setting a `width: max-content` on the marquee fixed the content lap issue - but when resizing the grid, it throws calcs into an infinite loop. I reverted display grid back to what we originally had which fixes the issue







