### PR TITLE
feat: ignore major semvar packages from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,6 @@ updates:
       - "dependencies"
     reviewers:
       - "wethegit/developers"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Description

Updates `dependabot.yml` to ignore major semvar package updates.

## Notes

Since this doesn't touch any of the package code, I targeted this for `main` instead of a release branch.