### PR TITLE
fix: update URLs for demo component

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -22,24 +22,9 @@ function App() {
 function Slide() {
   return (
     <>
-      <img
-        src="https://source.unsplash.com/random/200x400"
-        alt=""
-        width="200"
-        height="400"
-      />
-      <img
-        src="https://source.unsplash.com/random/500x500"
-        alt=""
-        width="500"
-        height="500"
-      />
-      <img
-        src="https://source.unsplash.com/random/640x360"
-        alt=""
-        width="640"
-        height="360"
-      />
+      <img src="https://unsplash.it/200/400?random" alt="" width="200" height="400" />
+      <img src="https://unsplash.it/500/500?random" alt="" width="500" height="500" />
+      <img src="https://unsplash.it/640/360?random" alt="" width="640" height="360" />
     </>
   )
 }


### PR DESCRIPTION
## Description

This PR updates `main.jsx` (soon to be `main.tsx`) to use newer versions of Unsplash URLs.

## Notes

The Source part of Unsplash has been deprecated, but these new URLs work for grabbing random images.