### PR TITLE
Add reverse option

### DIFF
--- a/.changeset/green-hairs-draw.md
+++ b/.changeset/green-hairs-draw.md
@@ -1,0 +1,5 @@
+---
+"@wethegit/react-marquee": patch
+---
+
+Add "reverse" option

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wethegit/react-marquee",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wethegit/react-marquee",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
         "@changesets/changelog-github": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/react-marquee",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "",
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/react-marquee",
-  "version": "2.1.2",
+  "version": "2.1.1",
   "description": "",
   "files": [
     "dist"

--- a/src/lib/marquee.scss
+++ b/src/lib/marquee.scss
@@ -34,3 +34,7 @@
   */
   animation: scroll var(--duration) linear infinite var(--animation-state, running);
 }
+
+.marquee--reverse {
+  animation-direction: reverse;
+}

--- a/src/lib/marquee.tsx
+++ b/src/lib/marquee.tsx
@@ -25,6 +25,10 @@ export interface MarqueeProps extends React.ComponentPropsWithoutRef<"div"> {
    * Default value is 50.
    */
   speed?: number
+  /**
+   * Whether to animate from left to right
+   */
+  reverse?: boolean
 }
 
 type Timer = ReturnType<typeof setTimeout>
@@ -34,6 +38,7 @@ export function Marquee({
   reducedMotionSpeed = 20,
   prefersReducedMotion = false,
   playing = true,
+  reverse,
   children,
   className,
   ...props
@@ -98,7 +103,12 @@ export function Marquee({
     <div
       {...props}
       ref={container}
-      className={classnames(["marquee", marqueeWidth > 0 && "marquee--ready", className])}
+      className={classnames([
+        "marquee",
+        marqueeWidth > 0 && "marquee--ready",
+        reverse && "marquee--reverse",
+        className,
+      ])}
       style={
         {
           "--marquee-width": marqueeWidth,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,11 @@ function App() {
         <Slide />
       </Marquee>
 
+      <h1>Reversed</h1>
+      <Marquee speed={100} reducedMotionSpeed={20} reverse>
+        <Slide />
+      </Marquee>
+
       <h1>Paused</h1>
       <Marquee playing={false}>
         <Slide />


### PR DESCRIPTION
Ticket: https://wethecollective.teamwork.com/app/tasks/22769488

### Description

Adds a new prop, `reverse`, which simply reverses the direction of the animation.

### Additional Notes
- It looks like `changeset` might not be working for this repo :( If that's the case I'll bump the version manually.
- This package could use an upgrade to CSS Modules, but I will leave that for a major version bump later on.

### Usage
```jsx
<Marquee speed={20} reverse>
  <img src="image-1.png" alt="" width="500" height="500" />
  <img src="image-2.png" alt="" width="500" height="500" />
  <img src="image-3.png" alt="" width="500" height="500" />
</Marquee>
```